### PR TITLE
Library loading changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ bin/
 obj/
 /.fake/
 /paket-files/
+/.vs/
 /.vscode/
 nuget/*.paket.template

--- a/WebSharper.Google.Visualization.Tests/Samples.fs
+++ b/WebSharper.Google.Visualization.Tests/Samples.fs
@@ -35,8 +35,6 @@ module Client =
         open WebSharper
         [<Inline "alert($msg)">]
         let Alert (msg: obj) : unit = X
-        [<Inline "google.setOnLoadCallback($x)">]
-        let OnLoad (x: unit -> unit) : unit = X
 
     module Data =
 
@@ -736,39 +734,42 @@ module Client =
 
         [<JavaScript>]
         override this.Body =
-            Div [
-                 H1 [Text "Google Viz Samples"]
-                 TreeMap ()
-                 AreaChartEvents ()
-                 ArrowFormat ()
-                 BarFormat ()
-                 ColorFormat ()
-                 DateFormat ()
-                 NumberFormat ()
-                 PatternFormat ()
-                 OrgChart ()
-                 ScatterChart ()
-                 PieChart ()
-                 MotionChart ()
-                 BlogMotionChart ()
-                 IntensityMap ()
-                 LineChart ()
-                 GeoMap ()
-                 GeoMapMarkers ()
-                 ColumnChart ()
-                 BarChart ()
-                 AreaChart ()
-                 Gauge ()
-                 ColorObject ()
-                 Timeline ()
-                 TableExample ()
-                 ViewExample ()
-                 TableWithRowNumbers ()
-
+            let container = Div [
+                    H1 [Text "Google Viz Samples"]
                 ]
-                |> fun x -> JQuery.JQuery.Of(x.Dom).Children().Width(440).Ignore; x
-                :> _
-
+            GoogleCharts.OnLoad (fun () ->
+                [
+                    TreeMap ()
+                    AreaChartEvents ()
+                    ArrowFormat ()
+                    BarFormat ()
+                    ColorFormat ()
+                    DateFormat ()
+                    NumberFormat ()
+                    PatternFormat ()
+                    OrgChart ()
+                    ScatterChart ()
+                    PieChart ()
+                    MotionChart ()
+                    BlogMotionChart ()
+                    IntensityMap ()
+                    LineChart ()
+                    GeoMap ()
+                    GeoMapMarkers ()
+                    ColumnChart ()
+                    BarChart ()
+                    AreaChart ()
+                    Gauge ()
+                    ColorObject ()
+                    Timeline ()
+                    TableExample ()
+                    ViewExample ()
+                    TableWithRowNumbers ()
+                ]
+                |> List.iter container.Append
+                JQuery.JQuery.Of(container.Dom).Children().Width(440).Ignore
+            )
+            container :> _
 
 open WebSharper.Sitelets
 

--- a/WebSharper.Google.Visualization/Base.fs
+++ b/WebSharper.Google.Visualization/Base.fs
@@ -1259,7 +1259,7 @@ type ChartOptionsCommon [<Inline "{}">] () =
     [<DefaultValue>]
     val mutable width : int
 
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 type ChartCommon<'Options> internal () =
 
     inherit ChartLayoutInterface()

--- a/WebSharper.Google.Visualization/Events.fs
+++ b/WebSharper.Google.Visualization/Events.fs
@@ -26,7 +26,7 @@ open WebSharper.JavaScript
 open WebSharper.Google.Visualization
 open WebSharper.Google.Visualization.Base
 
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 module Events = 
 
     module private Visualizations =

--- a/WebSharper.Google.Visualization/IntensityMap.fs
+++ b/WebSharper.Google.Visualization/IntensityMap.fs
@@ -86,7 +86,7 @@ type IntensityMapOptions [<Inline "{}">] () =
 
 /// An intensity map that highlights regions or countries based on relative values 
 [<Name "google.visualization.IntensityMap">]
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 [<Require(typeof<Dependencies.IntensityMap>)>]
 type IntensityMap =
     [<Stub>]

--- a/WebSharper.Google.Visualization/MotionChart.fs
+++ b/WebSharper.Google.Visualization/MotionChart.fs
@@ -86,7 +86,7 @@ type MotionChartOptions [<Inline "{}">] () =
 /// A dynamic chart to explore several indicators over time. The chart is rendered within 
 /// the browser using Flash.
 [<Name "google.visualization.MotionChart">]
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 [<Require(typeof<Dependencies.MotionChart>)>]
 type MotionChart =
     [<Stub>]

--- a/WebSharper.Google.Visualization/OrgChart.fs
+++ b/WebSharper.Google.Visualization/OrgChart.fs
@@ -56,7 +56,7 @@ type OrgChartOptions [<Inline "{}">] () =
 /// A line chart that is rendered within the browser using SVG or VML. Displays 
 /// tips when clicking on points. Animates lines when clicking on legend entries. 
 [<Name "google.visualization.OrgChart">]
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 [<Require(typeof<Dependencies.OrgChart>)>]
 type OrgChart =
     [<Stub>]

--- a/WebSharper.Google.Visualization/Query.fs
+++ b/WebSharper.Google.Visualization/Query.fs
@@ -82,7 +82,7 @@ type QueryResponse =
 
 /// Represents a query that is sent to a data source.
 [<Name "google.visualization.Query">]
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 type Query =
 
     /// <param name="dataSourceUrl">

--- a/WebSharper.Google.Visualization/Regions.fs
+++ b/WebSharper.Google.Visualization/Regions.fs
@@ -27,7 +27,7 @@ open WebSharper.Google.Visualization
 open WebSharper.Google.Visualization.Base
 
 /// Dummy type to simulate the region enumeration.
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 type Region =
     [<Inline "$s">]
     static member FromString (s: string) : Region = X

--- a/WebSharper.Google.Visualization/Table.fs
+++ b/WebSharper.Google.Visualization/Table.fs
@@ -197,7 +197,7 @@ type SortInfo = {
 }
 
 [<Name "google.visualization.Table">]
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 [<Require(typeof<Dependencies.Table>)>]
 type Table =
     [<Stub>]

--- a/WebSharper.Google.Visualization/TimeLine.fs
+++ b/WebSharper.Google.Visualization/TimeLine.fs
@@ -65,7 +65,7 @@ type TimelineOptions [<Inline "{}">] () =
     val mutable width : int
 
 [<Name "google.visualization.Timeline">]
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 [<Require(typeof<Dependencies.Timeline>)>]
 type Timeline [<Stub>] (elem: Dom.Element) =
 

--- a/WebSharper.Google.Visualization/TreeMap.fs
+++ b/WebSharper.Google.Visualization/TreeMap.fs
@@ -102,7 +102,7 @@ type TreeMapOptions [<Inline "{}">] () =
 /// A visual representation of a data tree, where each node can have zero or more children, and one parent (except for the root, which has no parents). Each node is displayed as a rectangle, sized and colored according to values that you assign. Sizes and colors are valued relative to all other nodes in the graph. You can specify how many levels to display simultaneously, and optionally to display deeper levels in a hinted fashion. If a node is a leaf node, you can specify a size and color; if it is not a leaf, it will be displayed as a bounding box for leaf nodes. The default behavior is to move down the tree when a user left-clicks a node, and to move back up the tree when a user right-clicks the graph.
 /// The total size of the graph is determined by the size of the containing element that you insert in your page. If you have leaf nodes with names too long to show, the name will be truncated with an ellipsis (...).
 [<Name "google.visualization.TreeMap">]
-[<Require(typeof<Dependencies.JsApi>)>]
+[<Require(typeof<Dependencies.GoogleCharts>)>]
 [<Require(typeof<Dependencies.TreeMap>)>]
 type TreeMap =
     [<Stub>]


### PR DESCRIPTION
- Updated the load call to use the new library.
- Selected version 45.2 by default, which is the last version that was provided to the old load method.
- Added settings for which version to load and to provide a Google Maps API key.
- Waited for the OnLoad callback before using the library in the test samples.
- References
https://forums.websharper.com/topic/88162
https://developers.google.com/chart/interactive/docs/basic_load_libs#updateloader